### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://mrbgristwood.visualstudio.com/2cb7f0bb-973f-45e7-a756-d4ac24859d29/04367729-3572-4be4-9dc8-43be0b2123a0/_apis/work/boardbadge/6dd65d3b-e1e7-486d-ac62-74d4b6dede41)](https://mrbgristwood.visualstudio.com/2cb7f0bb-973f-45e7-a756-d4ac24859d29/_boards/board/t/04367729-3572-4be4-9dc8-43be0b2123a0/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://mrbgristwood.visualstudio.com/2cb7f0bb-973f-45e7-a756-d4ac24859d29/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.